### PR TITLE
Fix configuration example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Here's an example:
 
 ```
 threshold: 85
-metric: stmt
+thresholdType: stmt
 root: "github.com/mcubik/goverreport"
 exclusions: [test/it] # Exclude packages prefixed with "test/it"
 ```


### PR DESCRIPTION
`metric` didn't work - `thresholdType` is the correct configuration keyword.